### PR TITLE
fix typo in 'colour'…

### DIFF
--- a/plugins/nobbz/lua/nobbz/noice.lua
+++ b/plugins/nobbz/lua/nobbz/noice.lua
@@ -1,5 +1,5 @@
 require("notify").setup({
-  background_color = "#000000",
+  background_colour = "#000000",
 })
 
 require("noice").setup({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated spelling of configuration key from "background_color" to "background_colour"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->