### PR TITLE
do not init beancount LSP if there is no git repo

### DIFF
--- a/plugins/nobbz/lua/nobbz/lsp/beancount.lua
+++ b/plugins/nobbz/lua/nobbz/lsp/beancount.lua
@@ -3,11 +3,16 @@ local helpers = require("nobbz.lsp.helpers")
 -- find the root dir of the project by finding a .git folder
 local root_dir = vim.fs.dirname(vim.fs.find({ ".git", }, { upward = true, })[1])
 -- the main journal always is "main.beancount" at the repo root
-local journal_file = vim.fs.joinpath(root_dir, "main.beancount")
+local journal_file = nil
+if root_dir ~= nil then
+  vim.fs.joinpath(root_dir, "main.beancount")
+end
 
-require("lspconfig").beancount.setup({
-  on_attach = helpers.keymap,
-  capabilities = LSP_CAPAS,
-  root_dir = root_dir,
-  init_options = { journal_file = journal_file, },
-})
+if root_dir ~= nil and journal_file ~= nil then
+  require("lspconfig").beancount.setup({
+    on_attach = helpers.keymap,
+    capabilities = LSP_CAPAS,
+    root_dir = root_dir,
+    init_options = { journal_file = journal_file, },
+  })
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Beancount language service initialization to ensure it only activates when all required configurations are present, reducing the risk of errors during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->