### PR TITLE
remove rustfmt from null-ls config to avoid a pop up on each start

### DIFF
--- a/plugins/nobbz/lua/nobbz/lsp.lua
+++ b/plugins/nobbz/lua/nobbz/lsp.lua
@@ -4,7 +4,6 @@ local diagnostics = null_ls.builtins.diagnostics
 local code_actions = null_ls.builtins.code_actions
 local ls_sources = {
   -- formatting.stylua,
-  formatting.rustfmt,
   formatting.alejandra,
   --code_actions.statix,
   --diagnostics.deadnix,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed support for the Rust formatting tool from the available formatting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->