### PR TITLE
disable blink for cmdline

### DIFF
--- a/plugins/nobbz/lua/nobbz/blink.lua
+++ b/plugins/nobbz/lua/nobbz/blink.lua
@@ -2,6 +2,9 @@ local winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:Pmen
 
 require("blink.cmp").setup({
   snippets = { preset = "luasnip", },
+  -- I'd like to keep it enabled for search, while disabling for command line.
+  -- see https://github.com/Saghen/blink.cmp/discussions/1580
+  cmdline = { enabled = false, },
   signature = {
     enabled = true,
     window = { border = "single", },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the command line behavior through a new configuration option. The command line functionality is now disabled by default during standard operations, while support remains available for search-specific interactions. This update refines the user experience by clearly aligning functionality with different usage contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->