### PR TITLE
disable neogit commit message wrap

### DIFF
--- a/plugins/nobbz/lua/nobbz/git.lua
+++ b/plugins/nobbz/lua/nobbz/git.lua
@@ -3,6 +3,14 @@ local neogit = require("neogit")
 
 neogit.setup({})
 
+-- disable line breaks in gitcommit mode (it is annoying!)
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "gitcommit",
+  callback = function()
+    vim.opt_local.textwidth = 0
+  end,
+})
+
 -- register keys for neogit
 WK.add({
   { "<leader>g",   group = "git", },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automatic command in the Neovim setup that disables automatic line wrapping when editing Git commit messages, improving the commit editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->