### PR TITLE
gleam snippet for externals

### DIFF
--- a/plugins/nobbz/lua/nobbz/blink.lua
+++ b/plugins/nobbz/lua/nobbz/blink.lua
@@ -3,6 +3,11 @@ local luasnip = require("luasnip")
 
 local winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel"
 
+local function is_hidden_snippet()
+  local ls = require("luasnip")
+  return not require("blink.cmp").is_visible() and not ls.in_snippet() and ls.expandable()
+end
+
 blink.setup({
   snippets = {
     -- preset = "luasnip",
@@ -13,6 +18,11 @@ blink.setup({
         if not luasnip.in_snippet() and vim.fn.mode() == "n" then luasnip.unlink_current() end
         return false
       end
+    end,
+    expand = function(snippet) luasnip.lsp_expand(snippet) end,
+    jump = function(direction)
+      if is_hidden_snippet() then return luasnip.expand_or_jump() end
+      return luasnip.jumpable(direction) and luasnip.jump(direction)
     end,
   },
   -- I'd like to keep it enabled for search, while disabling for command line.

--- a/plugins/nobbz/lua/nobbz/blink.lua
+++ b/plugins/nobbz/lua/nobbz/blink.lua
@@ -10,7 +10,7 @@ end
 
 blink.setup({
   snippets = {
-    -- preset = "luasnip",
+    preset = "luasnip",
     active = function()
       if luasnip.in_snippet() and not blink.is_visible() then
         return true

--- a/plugins/nobbz/lua/nobbz/luasnip.lua
+++ b/plugins/nobbz/lua/nobbz/luasnip.lua
@@ -6,7 +6,7 @@ luasnip.config.setup({
 })
 
 WK.add({
-  { "<C-k>", luasnip.expand, desc = "expand snippet", },
+  { "<C-e>", luasnip.expand, desc = "expand snippet", mode = { "i", "s", }, },
 })
 
 local function script_path(suffix)

--- a/plugins/nobbz/lua/nobbz/luasnip.lua
+++ b/plugins/nobbz/lua/nobbz/luasnip.lua
@@ -1,12 +1,21 @@
-local luasnip = require("luasnip")
 local lualoader = require("luasnip.loaders.from_lua")
+local luasnip = require("luasnip")
+local select = require("luasnip.extras.select_choice")
 
 luasnip.config.setup({
   enable_autosnippets = true,
 })
 
+local function cycle()
+  if luasnip.choice_active() then
+    return luasnip.change_choice(1)
+  end
+end
+
 WK.add({
-  { "<C-e>", luasnip.expand, desc = "expand snippet", mode = { "i", "s", }, },
+  { "<C-e>",   luasnip.expand, desc = "expand snippet",            mode = { "i", "s", }, },
+  { "<C-j>",   cycle,          desc = "Cycle choices in node",     mode = { "i", "s", }, },
+  { "<C-S-j>", select,         desc = "UI select choices in node", mode = { "i", "s", }, },
 })
 
 local function script_path(suffix)

--- a/plugins/nobbz/lua/nobbz/luasnip/elixir.lua
+++ b/plugins/nobbz/lua/nobbz/luasnip/elixir.lua
@@ -1,0 +1,8 @@
+return {
+  s({ trig = "def:", name = "def oneliner", desc = "one line function definition", },
+    fmt("def {}({}), do: {}", { i(1, "name"), i(2, "args"), i(0, "body"), })),
+  s({ trig = "defp:", name = "defp oneliner", desc = "one line private function definition", },
+    fmt("defp {}({}), do: {}", { i(1, "name"), i(2, "args"), i(0, "body"), })),
+  s({ trig = ">d", name = "pipe debug", desc = "pipe into debug", },
+    fmt("|> dbg()")),
+}

--- a/plugins/nobbz/lua/nobbz/luasnip/gitcommit.lua
+++ b/plugins/nobbz/lua/nobbz/luasnip/gitcommit.lua
@@ -2,5 +2,5 @@ vim.print("luasnip loading")
 
 return {
   s({ trig = "sc", desc = "short-cut ticket", },
-    { t("[SC-"), i(1), t("]"), i(2), }),
+    { t("[SC-"), i(1), t("]"), i(0), }),
 }

--- a/plugins/nobbz/lua/nobbz/luasnip/gleam.lua
+++ b/plugins/nobbz/lua/nobbz/luasnip/gleam.lua
@@ -1,18 +1,15 @@
 return {
-  s({ trig = "external", desc = "external reference", },
-    { t("@external("),
+  s({ trig = "external", name = "external definition", desc = "external reference", },
+    fmt([[
+      @external({}, "{}", "{}")
+      pub fn {}({}) -> {}
+    ]], {
       c(1, { t("erlang"), t("javascript"), }),
-      t(", \""),
       i(2, "module"),
-      t("\", \""),
       i(3, "function"),
-      t("\")\npub fn "),
       i(4, "name"),
-      t("("),
       i(5, "args"),
-      t(")"),
-      t(" -> "),
-      i(6, "return"),
-      t("\n"),
-    }),
+      i(0, "return"),
+    })
+  ),
 }

--- a/plugins/nobbz/lua/nobbz/luasnip/gleam.lua
+++ b/plugins/nobbz/lua/nobbz/luasnip/gleam.lua
@@ -1,0 +1,18 @@
+return {
+  s({ trig = "external", desc = "external reference", },
+    { t("@external("),
+      c(1, { t("erlang"), t("javascript"), }),
+      t(", \""),
+      i(2, "module"),
+      t("\", \""),
+      i(3, "function"),
+      t("\")\npub fn "),
+      i(4, "name"),
+      t("("),
+      i(5, "args"),
+      t(")"),
+      t(" -> "),
+      i(6, "return"),
+      t("\n"),
+    }),
+}

--- a/plugins/nobbz/lua/nobbz/luasnip/lua.lua
+++ b/plugins/nobbz/lua/nobbz/luasnip/lua.lua
@@ -1,0 +1,23 @@
+local fun_string = [[function {}({})
+  {}
+end]]
+
+local module_string = [[local M = {{}}
+
+function M.{}({})
+  {}
+end
+
+return M]]
+
+local module_fun_string = [[function M.{}({})
+  {}
+end]]
+
+return {
+  s({ trig = "fn", name = "function", desc = "function definition", }, fmt(fun_string, { i(1, "name"), i(2), i(0), })),
+  s({ trig = "fnM", name = "module function", desc = "function definition in module", },
+    fmt(module_fun_string, { i(1, "name"), i(2), i(0), })),
+  s({ trig = "mod", name = "module", desc = "module definition", },
+    fmt(module_string, { i(1, "name"), i(2, "func"), i(3), i(0), })),
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new snippet sets for Elixir and Lua, enabling quick insertion of common function and module templates with interactive placeholders.
  - Introduced UI and keybindings for cycling through and selecting choices within active snippet nodes for enhanced snippet editing.
  
- **Improvements**
  - Changed snippet expansion keybinding to Ctrl+e, restricted to insert and select modes for better workflow.
  - Updated git commit snippet navigation to jump directly to the final input field after the first.
  - Enhanced snippet expansion and jump behavior by integrating snippet state with completion popup visibility for smoother editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->